### PR TITLE
ci: add parsing the tests output

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,27 @@
+name: Makefile CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: configure
+      run: ./configure
+
+    - name: Install dependencies
+      run: make
+
+    - name: Run check
+      run: make check
+
+    - name: Run distcheck
+      run: make distcheck

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -15,11 +15,17 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Initialize submodule
-      run: git submodule init
+    - name: Initialize & update submodule
+      run: config.sh
 
-    - name: Update submodule
-      run: git submodule update
-
-    - name: Run tests
-      run: make test
+    - name: Run & parse Test Results
+      run: |
+        output=$(make test)
+        failures=$(echo "$output" | sed -n '/FAILURES:/,/-----------------------/p')
+        if [ -n "$failures" ]; then
+          echo "Test failures detected:"
+          echo "$failures" | grep -v "-----------------------"
+          exit 1
+        else
+          echo "All tests passed."
+        fi

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -14,14 +15,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: configure
-      run: ./configure
+    - name: Initialize submodule
+      run: git submodule init
 
-    - name: Install dependencies
-      run: make
+    - name: Update submodule
+      run: git submodule update
 
-    - name: Run check
-      run: make check
-
-    - name: Run distcheck
-      run: make distcheck
+    - name: Run tests
+      run: make test


### PR DESCRIPTION
Removed the "git submodule" commands, by switching to a single .sh file. 
Adding task for executing and parsing the stdout of tests and providing the appropriate CI output.